### PR TITLE
Update outdated dependencies, use different source for chiaki.

### DIFF
--- a/.github/workflows/build-visual_studio-qt6.yml
+++ b/.github/workflows/build-visual_studio-qt6.yml
@@ -38,9 +38,9 @@ jobs:
       - name: Setup ffmpeg
         run: |
           $ProgressPreference = 'SilentlyContinue'
-          Invoke-WebRequest -UseBasicParsing -Uri "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-n5.0-latest-win64-gpl-shared-5.0.zip" -OutFile ".\ffmpeg-n5.0-latest-win64-gpl-shared-5.0.zip"
-          Expand-Archive -LiteralPath "ffmpeg-n5.0-latest-win64-gpl-shared-5.0.zip" -DestinationPath "."
-          Rename-Item "ffmpeg-n5.0-latest-win64-gpl-shared-5.0" "ffmpeg"
+          Invoke-WebRequest -UseBasicParsing -Uri "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-win64-gpl.zip" -OutFile ".\ffmpeg-master-latest-win64-gpl.zip"
+          Expand-Archive -LiteralPath "ffmpeg-master-latest-win64-gpl.zip" -DestinationPath "."
+          Rename-Item "ffmpeg-master-latest-win64-gpl" "ffmpeg"
           Write-Output "${{ github.workspace }}\ffmpeg\bin" | Out-File -FilePath $Env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Setup protoc

--- a/.github/workflows/build-visual_studio-qt6.yml
+++ b/.github/workflows/build-visual_studio-qt6.yml
@@ -38,9 +38,9 @@ jobs:
       - name: Setup ffmpeg
         run: |
           $ProgressPreference = 'SilentlyContinue'
-          Invoke-WebRequest -UseBasicParsing -Uri "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-win64-gpl.zip" -OutFile ".\ffmpeg-master-latest-win64-gpl.zip"
-          Expand-Archive -LiteralPath "ffmpeg-master-latest-win64-gpl.zip" -DestinationPath "."
-          Rename-Item "ffmpeg-master-latest-win64-gpl" "ffmpeg"
+          Invoke-WebRequest -UseBasicParsing -Uri "https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2022-03-31-12-54/ffmpeg-N-106467-ge301a24fa1-win64-gpl-shared.zip" -OutFile ".\ffmpeg-N-106467-ge301a24fa1-win64-gpl-shared.zip"
+          Expand-Archive -LiteralPath "ffmpeg-N-106467-ge301a24fa1-win64-gpl-shared.zip" -DestinationPath "."
+          Rename-Item "ffmpeg-N-106467-ge301a24fa1-win64-gpl-shared" "ffmpeg"
           Write-Output "${{ github.workspace }}\ffmpeg\bin" | Out-File -FilePath $Env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Setup protoc

--- a/.github/workflows/build-visual_studio-qt6.yml
+++ b/.github/workflows/build-visual_studio-qt6.yml
@@ -38,9 +38,9 @@ jobs:
       - name: Setup ffmpeg
         run: |
           $ProgressPreference = 'SilentlyContinue'
-          Invoke-WebRequest -UseBasicParsing -Uri "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-n6.0-latest-win64-gpl-shared-6.0.zip" -OutFile ".\ffmpeg-n6.0-latest-win64-gpl-shared-6.0.zip"
-          Expand-Archive -LiteralPath "ffmpeg-n6.0-latest-win64-gpl-shared-6.0.zip" -DestinationPath "."
-          Rename-Item "ffmpeg-n6.0-latest-win64-gpl-shared-6.0" "ffmpeg"
+          Invoke-WebRequest -UseBasicParsing -Uri "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-n5.1-latest-win64-gpl-shared-5.1.zip" -OutFile ".\ffmpeg-n5.1-latest-win64-gpl-shared-5.1.zip"
+          Expand-Archive -LiteralPath "ffmpeg-n5.1-latest-win64-gpl-shared-5.1.zip" -DestinationPath "."
+          Rename-Item "ffmpeg-n5.1-latest-win64-gpl-shared-5.1" "ffmpeg"
           Write-Output "${{ github.workspace }}\ffmpeg\bin" | Out-File -FilePath $Env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Setup protoc

--- a/.github/workflows/build-visual_studio-qt6.yml
+++ b/.github/workflows/build-visual_studio-qt6.yml
@@ -60,8 +60,8 @@ jobs:
       - name: Setup OpenSSL
         run: |
           $ProgressPreference = 'SilentlyContinue'
-          Invoke-WebRequest -UseBasicParsing -Uri "https://mirror.firedaemon.com/OpenSSL/openssl-1.1.1p.zip" -OutFile ".\openssl-1.1.1p.zip"
-          Expand-Archive -LiteralPath "openssl-1.1.1p.zip" -DestinationPath "."
+          Invoke-WebRequest -UseBasicParsing -Uri "https://download.firedaemon.com/FireDaemon-OpenSSL/openssl-1.1.1t.zip" -OutFile ".\openssl-1.1.1t.zip"
+          Expand-Archive -LiteralPath "openssl-1.1.1t.zip" -DestinationPath "."
           Rename-Item "openssl-1.1" "openssl"
           Write-Output "${{ github.workspace }}\openssl" | Out-File -FilePath $Env:GITHUB_PATH -Encoding utf8 -Append
 

--- a/.github/workflows/build-visual_studio-qt6.yml
+++ b/.github/workflows/build-visual_studio-qt6.yml
@@ -38,9 +38,9 @@ jobs:
       - name: Setup ffmpeg
         run: |
           $ProgressPreference = 'SilentlyContinue'
-          Invoke-WebRequest -UseBasicParsing -Uri "https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2022-03-31-12-54/ffmpeg-N-106467-ge301a24fa1-win64-gpl-shared.zip" -OutFile ".\ffmpeg-N-106467-ge301a24fa1-win64-gpl-shared.zip"
-          Expand-Archive -LiteralPath "ffmpeg-N-106467-ge301a24fa1-win64-gpl-shared.zip" -DestinationPath "."
-          Rename-Item "ffmpeg-N-106467-ge301a24fa1-win64-gpl-shared" "ffmpeg"
+          Invoke-WebRequest -UseBasicParsing -Uri "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-n6.0-latest-win64-gpl-shared-6.0.zip" -OutFile ".\ffmpeg-n6.0-latest-win64-gpl-shared-6.0.zip"
+          Expand-Archive -LiteralPath "ffmpeg-n6.0-latest-win64-gpl-shared-6.0.zip" -DestinationPath "."
+          Rename-Item "ffmpeg-n6.0-latest-win64-gpl-shared-6.0" "ffmpeg"
           Write-Output "${{ github.workspace }}\ffmpeg\bin" | Out-File -FilePath $Env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Setup protoc

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "chiaki"]
 	path = chiaki
-	url = https://git.sr.ht/~thestr4ng3r/chiaki
+	url = https://github.com/8bitDream/chiaki
 	branch = master


### PR DESCRIPTION
Thanks for this project, I came across when I was looking for a way of building chiaki from scratch. I forked your repository and changed the source but the `build-visual_studio-qt6` workflow failed due to missing resources, so I updated them. I don't know whether the existing source should already pick the latest commit on the updated source, so I can discard that line if this is the case.